### PR TITLE
feat(nav): add engineering dynamic menu

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -19,6 +19,12 @@ if (professionGuideNavItem.link && professionGuideNavItem.link !== '/blog/') {
   professionGuideNavItem.activeMatch = `^${escapeForRegExp(professionGuideNavItem.link)}$`
 }
 
+const engineeringPracticeLink = resolveLatestCategoryArticle('工程实践')
+const engineeringPracticeNavItem = { text: '工程', link: engineeringPracticeLink || '/blog/' }
+if (engineeringPracticeNavItem.link && engineeringPracticeNavItem.link !== '/blog/') {
+  engineeringPracticeNavItem.activeMatch = `^${escapeForRegExp(engineeringPracticeNavItem.link)}$`
+}
+
 const pagefindExcludeSelectors = ['div.aside', 'a.header-anchor']
 const pagefindForceLanguage = (process.env.PAGEFIND_FORCE_LANGUAGE || '').trim()
 const pagefindCommandParts = [
@@ -76,6 +82,7 @@ export default defineConfig({
     nav: [
       { text: '博客', link: '/blog/' },
       professionGuideNavItem,
+      engineeringPracticeNavItem,
       { text: '作品', link: '/portfolio/' },
       { text: '关于', link: '/about/' }
     ],


### PR DESCRIPTION
## Summary
- add an "工程" navigation item that links to the most recent article tagged with "工程实践"
- mirror the existing 攻略 menu pattern so the engineering column can omit an index page while staying discoverable

## Testing
- npm run docs:build

------
https://chatgpt.com/codex/tasks/task_e_68cd6370f5588325aa9b28bc3da513a6