### PR TITLE
fix(theme): justify article paragraphs

### DIFF
--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -9,6 +9,7 @@ const extendedTheme: VitePressTheme = {
     Theme.enhanceApp?.(ctx)
     if (inBrowser) {
       setupCategoryNavPersistence(ctx)
+      setupParagraphJustify(ctx)
     }
   }
 }
@@ -58,6 +59,33 @@ function setupCategoryNavPersistence(ctx: EnhanceAppContext) {
   }
 
   handleRouteChange(states, ctx.router.route.data, themeConfig, base)
+}
+
+const PARAGRAPH_SELECTOR = '.vp-doc p'
+
+function setupParagraphJustify(ctx: EnhanceAppContext) {
+  const apply = () => {
+    requestAnimationFrame(() => {
+      const paragraphs = document.querySelectorAll<HTMLElement>(PARAGRAPH_SELECTOR)
+      paragraphs.forEach((paragraph) => {
+        paragraph.style.textAlign = 'justify'
+      })
+    })
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', apply, { once: true })
+  } else {
+    apply()
+  }
+
+  const previous = ctx.router.onAfterRouteChange
+  ctx.router.onAfterRouteChange = async (to: string) => {
+    if (typeof previous === 'function') {
+      await previous.call(ctx.router, to)
+    }
+    apply()
+  }
 }
 
 function buildCategoryStates(navItems: NavRecord[], base: string) {


### PR DESCRIPTION
## Summary
- apply inline text justification for article paragraphs during client navigation

## Testing
- npm run docs:build

------
https://chatgpt.com/codex/tasks/task_e_68ce83839b548325bf3ecbc681c11021