### PR TITLE
fix: justify multiline paragraphs only

### DIFF
--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -62,21 +62,30 @@ function setupCategoryNavPersistence(ctx: EnhanceAppContext) {
 }
 
 const PARAGRAPH_SELECTOR = '.vp-doc p'
+const JUSTIFY_ATTR = 'xlJustifyApplied'
+const ORIGINAL_ALIGN_ATTR = 'xlOriginalAlign'
+const MULTILINE_THRESHOLD = 1.5
 
 function setupParagraphJustify(ctx: EnhanceAppContext) {
-  const apply = () => {
-    requestAnimationFrame(() => {
+  let rafId: number | null = null
+
+  const scheduleApply = () => {
+    if (rafId !== null) {
+      cancelAnimationFrame(rafId)
+    }
+    rafId = requestAnimationFrame(() => {
+      rafId = null
       const paragraphs = document.querySelectorAll<HTMLElement>(PARAGRAPH_SELECTOR)
-      paragraphs.forEach((paragraph) => {
-        paragraph.style.textAlign = 'justify'
-      })
+      paragraphs.forEach(updateParagraphAlignment)
     })
   }
 
+  const handleResize = () => scheduleApply()
+
   if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', apply, { once: true })
+    document.addEventListener('DOMContentLoaded', scheduleApply, { once: true })
   } else {
-    apply()
+    scheduleApply()
   }
 
   const previous = ctx.router.onAfterRouteChange
@@ -84,7 +93,76 @@ function setupParagraphJustify(ctx: EnhanceAppContext) {
     if (typeof previous === 'function') {
       await previous.call(ctx.router, to)
     }
-    apply()
+    scheduleApply()
+  }
+
+  window.addEventListener('resize', handleResize, { passive: true })
+}
+
+function updateParagraphAlignment(paragraph: HTMLElement) {
+  if (shouldApplyJustify(paragraph)) {
+    applyJustifyAlignment(paragraph)
+  } else {
+    restoreParagraphAlignment(paragraph)
+  }
+}
+
+function shouldApplyJustify(paragraph: HTMLElement) {
+  const styles = window.getComputedStyle(paragraph)
+  const computedAlign = styles.textAlign
+  if (
+    paragraph.dataset[JUSTIFY_ATTR] !== 'true' &&
+    computedAlign &&
+    computedAlign !== 'start' &&
+    computedAlign !== 'left' &&
+    computedAlign !== 'justify'
+  ) {
+    return false
+  }
+
+  let lineHeight = parseFloat(styles.lineHeight)
+  if (!Number.isFinite(lineHeight) || lineHeight <= 0) {
+    const fontSize = parseFloat(styles.fontSize)
+    if (Number.isFinite(fontSize) && fontSize > 0) {
+      lineHeight = fontSize * 1.4
+    } else {
+      return false
+    }
+  }
+
+  const paddingTop = parseFloat(styles.paddingTop) || 0
+  const paddingBottom = parseFloat(styles.paddingBottom) || 0
+  const borderTop = parseFloat(styles.borderTopWidth) || 0
+  const borderBottom = parseFloat(styles.borderBottomWidth) || 0
+  const contentHeight =
+    paragraph.getBoundingClientRect().height - paddingTop - paddingBottom - borderTop - borderBottom
+
+  if (!Number.isFinite(contentHeight) || contentHeight <= 0) {
+    return false
+  }
+
+  const lineCount = contentHeight / lineHeight
+  return lineCount > MULTILINE_THRESHOLD
+}
+
+function applyJustifyAlignment(paragraph: HTMLElement) {
+  if (!paragraph.dataset[JUSTIFY_ATTR]) {
+    paragraph.dataset[ORIGINAL_ALIGN_ATTR] = paragraph.style.textAlign || ''
+  }
+  paragraph.dataset[JUSTIFY_ATTR] = 'true'
+  paragraph.style.textAlign = 'justify'
+}
+
+function restoreParagraphAlignment(paragraph: HTMLElement) {
+  if (paragraph.dataset[JUSTIFY_ATTR] === 'true') {
+    const original = paragraph.dataset[ORIGINAL_ALIGN_ATTR] || ''
+    if (original) {
+      paragraph.style.textAlign = original
+    } else {
+      paragraph.style.removeProperty('text-align')
+    }
+    delete paragraph.dataset[JUSTIFY_ATTR]
+    delete paragraph.dataset[ORIGINAL_ALIGN_ATTR]
   }
 }
 


### PR DESCRIPTION
## Summary
- measure paragraph line count and only apply `text-align: justify` when the content wraps onto multiple lines
- restore the original alignment for single-line paragraphs and reschedule justification after route changes and window resizes

## Testing
- `CI=1 npm run docs:build`


------
https://chatgpt.com/codex/tasks/task_e_68ce88500c508325b16d906543dc796a