### PR TITLE
chore(theme): adopt pantone mocha mousse palette

### DIFF
--- a/blog-admin/public/style.css
+++ b/blog-admin/public/style.css
@@ -3,19 +3,19 @@
 }
 
 :root {
-  --brand-1: #4F46E5;
-  --brand-2: #6366F1;
-  --brand-3: #4338CA;
+  --brand-1: #A1745D;
+  --brand-2: #C18F6D;
+  --brand-3: #8C5E45;
   --accent: #F59E0B;
   --bg-soft: #EEF2FF;
   --bg-surface: #FFFFFF;
   --bg-overlay: rgba(255, 255, 255, 0.82);
-  --card-border: rgba(79, 70, 229, 0.18);
-  --card-shadow: 0 16px 40px rgba(79, 70, 229, 0.12);
+  --card-border: rgba(161, 116, 93, 0.18);
+  --card-shadow: 0 16px 40px rgba(161, 116, 93, 0.12);
   --text-1: #111827;
   --text-2: #4B5563;
   --text-muted: #6B7280;
-  --divider: rgba(99, 102, 241, 0.16);
+  --divider: rgba(193, 143, 109, 0.16);
   --radius-lg: 18px;
   --radius-md: 14px;
   --transition: all 0.18s ease;
@@ -86,8 +86,8 @@ h2 {
 }
 
 .card:hover {
-  border-color: rgba(79, 70, 229, 0.32);
-  box-shadow: 0 20px 48px rgba(79, 70, 229, 0.18);
+  border-color: rgba(161, 116, 93, 0.32);
+  box-shadow: 0 20px 48px rgba(161, 116, 93, 0.18);
 }
 
 .grid {
@@ -114,7 +114,7 @@ textarea {
   background: rgba(255, 255, 255, 0.9);
   color: var(--text-1);
   transition: var(--transition);
-  box-shadow: inset 0 1px 2px rgba(79, 70, 229, 0.08);
+  box-shadow: inset 0 1px 2px rgba(161, 116, 93, 0.08);
 }
 
 input:focus,
@@ -122,7 +122,7 @@ select:focus,
 textarea:focus {
   outline: none;
   border-color: var(--brand-2);
-  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.18);
+  box-shadow: 0 0 0 3px rgba(193, 143, 109, 0.18);
 }
 
 button {
@@ -130,26 +130,26 @@ button {
   padding: 6px 10px;
   border-radius: 9px;
   font-size: 0.7rem;
-  border: 1px solid rgba(79, 70, 229, 0.26);
-  background: linear-gradient(135deg, rgba(129, 140, 248, 0.18), rgba(99, 102, 241, 0.28));
+  border: 1px solid rgba(161, 116, 93, 0.26);
+  background: linear-gradient(135deg, rgba(212, 168, 137, 0.18), rgba(193, 143, 109, 0.28));
   color: var(--brand-3);
   cursor: pointer;
   font-weight: 600;
   letter-spacing: 0.02em;
   transition: var(--transition);
-  box-shadow: 0 10px 22px rgba(79, 70, 229, 0.18);
+  box-shadow: 0 10px 22px rgba(161, 116, 93, 0.18);
 }
 
 button:hover {
   transform: translateY(-1px);
-  background: linear-gradient(135deg, rgba(129, 140, 248, 0.26), rgba(99, 102, 241, 0.34));
-  box-shadow: 0 14px 28px rgba(79, 70, 229, 0.22);
+  background: linear-gradient(135deg, rgba(212, 168, 137, 0.26), rgba(193, 143, 109, 0.34));
+  box-shadow: 0 14px 28px rgba(161, 116, 93, 0.22);
 }
 
 button:active {
   transform: translateY(0);
-  background: linear-gradient(135deg, rgba(129, 140, 248, 0.22), rgba(99, 102, 241, 0.3));
-  box-shadow: 0 8px 18px rgba(79, 70, 229, 0.18);
+  background: linear-gradient(135deg, rgba(212, 168, 137, 0.22), rgba(193, 143, 109, 0.3));
+  box-shadow: 0 8px 18px rgba(161, 116, 93, 0.18);
 }
 
 button:disabled {
@@ -160,14 +160,14 @@ button:disabled {
 }
 
 button.neutral {
-  background: rgba(99, 102, 241, 0.08);
+  background: rgba(193, 143, 109, 0.08);
   color: var(--brand-3);
-  border-color: rgba(79, 70, 229, 0.25);
+  border-color: rgba(161, 116, 93, 0.25);
   box-shadow: none;
 }
 
 button.neutral:hover {
-  background: rgba(99, 102, 241, 0.14);
+  background: rgba(193, 143, 109, 0.14);
   transform: none;
 }
 
@@ -204,7 +204,7 @@ table {
 }
 
 thead {
-  background: rgba(99, 102, 241, 0.08);
+  background: rgba(193, 143, 109, 0.08);
   color: var(--brand-3);
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -214,13 +214,13 @@ thead {
 th,
 td {
   padding: 12px;
-  border-bottom: 1px solid rgba(79, 70, 229, 0.12);
+  border-bottom: 1px solid rgba(161, 116, 93, 0.12);
   text-align: left;
   font-size: 13px;
 }
 
 tbody tr:hover {
-  background: rgba(99, 102, 241, 0.05);
+  background: rgba(193, 143, 109, 0.05);
 }
 
 td .row-actions {
@@ -239,7 +239,7 @@ td .row-actions button {
   gap: 6px;
   padding: 4px 10px;
   border-radius: 999px;
-  background: rgba(79, 70, 229, 0.1);
+  background: rgba(161, 116, 93, 0.1);
   color: var(--brand-3);
   font-size: 12px;
   font-weight: 500;
@@ -260,9 +260,9 @@ td .row-actions button {
   min-width: 240px;
   max-width: 360px;
   background: var(--bg-overlay);
-  border: 1px solid rgba(79, 70, 229, 0.25);
+  border: 1px solid rgba(161, 116, 93, 0.25);
   border-radius: var(--radius-md);
-  box-shadow: 0 20px 40px rgba(79, 70, 229, 0.16);
+  box-shadow: 0 20px 40px rgba(161, 116, 93, 0.16);
   color: var(--text-1);
   padding: 14px 18px;
   opacity: 0;
@@ -276,7 +276,7 @@ td .row-actions button {
 }
 
 code {
-  background: rgba(79, 70, 229, 0.12);
+  background: rgba(161, 116, 93, 0.12);
   color: var(--brand-3);
   padding: 2px 6px;
   border-radius: 8px;
@@ -301,7 +301,7 @@ code {
 .login-card {
   width: min(100%, 360px);
   background: linear-gradient(160deg, rgba(255, 255, 255, 0.96), rgba(238, 242, 255, 0.92));
-  border: 1px solid rgba(79, 70, 229, 0.2);
+  border: 1px solid rgba(161, 116, 93, 0.2);
   border-radius: var(--radius-lg);
   box-shadow: 0 24px 60px rgba(17, 24, 39, 0.25);
   padding: 32px;

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -74,7 +74,7 @@ export default defineConfig({
   base: deployBase,
   appearance: true,
   head: [
-    ['meta', { name: 'theme-color', content: '#4F46E5' }],
+    ['meta', { name: 'theme-color', content: '#A1745D' }],
     ['link', { rel: 'icon', href: '/favicon.svg', type: 'image/svg+xml' }]
   ],
   themeConfig: {

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,8 +1,8 @@
 :root {
   /* 品牌与辅助色 */
-  --vp-c-brand-1: #4F46E5; /* indigo */
-  --vp-c-brand-2: #6366F1;
-  --vp-c-brand-3: #4338CA;
+  --vp-c-brand-1: #A1745D; /* mocha mousse */
+  --vp-c-brand-2: #C18F6D;
+  --vp-c-brand-3: #8C5E45;
   --xl-accent: #F59E0B; /* amber */
 
   /* 卡片与阴影 */
@@ -11,9 +11,9 @@
 }
 
 html.dark {
-  --vp-c-brand-1: #818CF8;
-  --vp-c-brand-2: #A5B4FC;
-  --vp-c-brand-3: #6366F1;
+  --vp-c-brand-1: #D4A889;
+  --vp-c-brand-2: #E6BFA0;
+  --vp-c-brand-3: #C18F6D;
   --xl-shadow: 0 12px 30px rgba(0, 0, 0, 0.35);
 }
 
@@ -97,7 +97,7 @@ html.dark {
 .xl-card:hover {
   transform: translateY(-2px);
   border-color: var(--vp-c-brand-1);
-  box-shadow: 0 10px 28px rgba(79, 70, 229, .18);
+  box-shadow: 0 10px 28px rgba(161, 116, 93, .18);
 }
 .xl-card h3 {
   margin: 8px 0;

--- a/docs/index.md
+++ b/docs/index.md
@@ -132,9 +132,9 @@ onUnmounted(() => {
     <svg viewBox="0 0 1200 800" role="img">
       <defs>
         <radialGradient id="heroGradient" cx="50%" cy="38%" r="62%">
-          <stop offset="0%" stop-color="#6366F1" stop-opacity="0.85" />
-          <stop offset="45%" stop-color="#4338CA" stop-opacity="0.45" />
-          <stop offset="100%" stop-color="#1E1B4B" stop-opacity="0" />
+          <stop offset="0%" stop-color="#C18F6D" stop-opacity="0.85" />
+          <stop offset="45%" stop-color="#8C5E45" stop-opacity="0.45" />
+          <stop offset="100%" stop-color="#2F1A13" stop-opacity="0" />
         </radialGradient>
         <linearGradient id="heroLines" x1="0%" x2="100%">
           <stop offset="0%" stop-color="#38BDF8" stop-opacity="0.8" />
@@ -263,25 +263,25 @@ onUnmounted(() => {
 }
 
 .xl-btn--primary {
-  background: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);
+  background: linear-gradient(135deg, #C18F6D 0%, #8C5E45 100%);
   color: white;
-  box-shadow: 0 18px 38px rgba(99, 102, 241, 0.32);
+  box-shadow: 0 18px 38px rgba(193, 143, 109, 0.32);
 }
 
 .xl-btn--primary:hover {
   transform: translateY(-2px);
-  box-shadow: 0 24px 46px rgba(99, 102, 241, 0.4);
+  box-shadow: 0 24px 46px rgba(193, 143, 109, 0.4);
 }
 
 .xl-btn--ghost {
-  border-color: rgba(129, 140, 248, 0.35);
+  border-color: rgba(212, 168, 137, 0.35);
   color: rgba(226, 232, 240, 0.9);
-  background: rgba(79, 70, 229, 0.12);
+  background: rgba(161, 116, 93, 0.12);
 }
 
 .xl-btn--ghost:hover {
   transform: translateY(-2px);
-  background: rgba(79, 70, 229, 0.2);
+  background: rgba(161, 116, 93, 0.2);
   color: white;
 }
 
@@ -306,7 +306,7 @@ onUnmounted(() => {
   display: block;
   width: 100%;
   height: 100%;
-  background: linear-gradient(90deg, rgba(99, 102, 241, 0.9), rgba(14, 165, 233, 0.9));
+  background: linear-gradient(90deg, rgba(193, 143, 109, 0.9), rgba(14, 165, 233, 0.9));
   transform-origin: left center;
   animation: hero-progress var(--hero-delay, 6000ms) linear forwards;
 }

--- a/docs/public/favicon.svg
+++ b/docs/public/favicon.svg
@@ -1,12 +1,12 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
   <defs>
     <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#4F46E5"/>
-      <stop offset="1" stop-color="#6366F1"/>
+      <stop offset="0" stop-color="#A1745D"/>
+      <stop offset="1" stop-color="#C18F6D"/>
     </linearGradient>
   </defs>
   <rect width="64" height="64" rx="14" ry="14" fill="url(#g)"/>
   <text x="50%" y="50%" dy=".35em" text-anchor="middle" font-size="34" font-family="system-ui, -apple-system, Segoe UI, Roboto, 'Noto Sans SC', 'PingFang SC', 'Microsoft YaHei', sans-serif" font-weight="700" fill="#fff">凌</text>
-  <!-- Primary: #4F46E5, Accent: #F59E0B -->
+  <!-- Primary: #A1745D, Accent: #F59E0B -->
 </svg>
 

--- a/docs/public/images/amazon-cover.svg
+++ b/docs/public/images/amazon-cover.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-label="D2R Amazon">
   <defs>
     <linearGradient id="g1" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#4F46E5"/>
-      <stop offset="1" stop-color="#6366F1"/>
+      <stop offset="0" stop-color="#A1745D"/>
+      <stop offset="1" stop-color="#C18F6D"/>
     </linearGradient>
     <linearGradient id="g2" x1="1" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#F59E0B" stop-opacity=".9"/>

--- a/docs/public/images/assassin-cover.svg
+++ b/docs/public/images/assassin-cover.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-label="D2R Assassin">
   <defs>
     <linearGradient id="g1" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#4F46E5"/>
-      <stop offset="1" stop-color="#6366F1"/>
+      <stop offset="0" stop-color="#A1745D"/>
+      <stop offset="1" stop-color="#C18F6D"/>
     </linearGradient>
     <linearGradient id="g2" x1="1" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#F59E0B" stop-opacity=".9"/>

--- a/docs/public/images/barbarian-cover.svg
+++ b/docs/public/images/barbarian-cover.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-label="D2R Barbarian">
   <defs>
     <linearGradient id="g1" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#4F46E5"/>
-      <stop offset="1" stop-color="#6366F1"/>
+      <stop offset="0" stop-color="#A1745D"/>
+      <stop offset="1" stop-color="#C18F6D"/>
     </linearGradient>
     <linearGradient id="g2" x1="1" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#F59E0B" stop-opacity=".9"/>

--- a/docs/public/images/blog-guide-cover.svg
+++ b/docs/public/images/blog-guide-cover.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-label="Blog guide cover">
   <defs>
     <linearGradient id="gb" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#4F46E5"/>
-      <stop offset="1" stop-color="#6366F1"/>
+      <stop offset="0" stop-color="#A1745D"/>
+      <stop offset="1" stop-color="#C18F6D"/>
     </linearGradient>
     <linearGradient id="ga" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#F59E0B" stop-opacity=".9"/>

--- a/docs/public/images/d2r-cover.svg
+++ b/docs/public/images/d2r-cover.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-label="D2R cover">
   <defs>
     <linearGradient id="g1" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#4F46E5"/>
-      <stop offset="1" stop-color="#6366F1"/>
+      <stop offset="0" stop-color="#A1745D"/>
+      <stop offset="1" stop-color="#C18F6D"/>
     </linearGradient>
     <linearGradient id="g2" x1="1" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#F59E0B" stop-opacity=".9"/>

--- a/docs/public/images/druid-cover.svg
+++ b/docs/public/images/druid-cover.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-label="D2R Druid">
   <defs>
     <linearGradient id="g1" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#4F46E5"/>
-      <stop offset="1" stop-color="#6366F1"/>
+      <stop offset="0" stop-color="#A1745D"/>
+      <stop offset="1" stop-color="#C18F6D"/>
     </linearGradient>
     <linearGradient id="g2" x1="1" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#F59E0B" stop-opacity=".9"/>

--- a/docs/public/images/necromancer-cover.svg
+++ b/docs/public/images/necromancer-cover.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-label="D2R Necromancer">
   <defs>
     <linearGradient id="g1" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#4F46E5"/>
-      <stop offset="1" stop-color="#6366F1"/>
+      <stop offset="0" stop-color="#A1745D"/>
+      <stop offset="1" stop-color="#C18F6D"/>
     </linearGradient>
     <linearGradient id="g2" x1="1" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#F59E0B" stop-opacity=".9"/>

--- a/docs/public/images/paladin-cover.svg
+++ b/docs/public/images/paladin-cover.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-label="D2R Paladin">
   <defs>
     <linearGradient id="g1" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#4F46E5"/>
-      <stop offset="1" stop-color="#6366F1"/>
+      <stop offset="0" stop-color="#A1745D"/>
+      <stop offset="1" stop-color="#C18F6D"/>
     </linearGradient>
     <linearGradient id="g2" x1="1" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#F59E0B" stop-opacity=".9"/>

--- a/docs/public/images/portfolio-guide-cover.svg
+++ b/docs/public/images/portfolio-guide-cover.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-label="Portfolio guide cover">
   <defs>
     <linearGradient id="g1" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#4F46E5"/>
-      <stop offset="1" stop-color="#6366F1"/>
+      <stop offset="0" stop-color="#A1745D"/>
+      <stop offset="1" stop-color="#C18F6D"/>
     </linearGradient>
     <linearGradient id="g2" x1="1" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#F59E0B" stop-opacity=".9"/>

--- a/docs/public/images/post-1758025324083-cover.svg
+++ b/docs/public/images/post-1758025324083-cover.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
-  <rect width="1200" height="630" fill="#4F46E5"/>
+  <rect width="1200" height="630" fill="#A1745D"/>
   <text x="60" y="200" font-size="48" fill="#fff" font-weight="700">测试文章</text>
   <text x="60" y="260" font-size="20" fill="#fff" opacity=".8">Generated at 2025/09/16 20:22:04</text>
 </svg>

--- a/docs/public/images/post-20250914-155212-cover.svg
+++ b/docs/public/images/post-20250914-155212-cover.svg
@@ -2,8 +2,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-label="测试博文：时间一致性验证">
   <defs>
     <linearGradient id="g1" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#4F46E5"/>
-      <stop offset="1" stop-color="#6366F1"/>
+      <stop offset="0" stop-color="#A1745D"/>
+      <stop offset="1" stop-color="#C18F6D"/>
     </linearGradient>
     <linearGradient id="g2" x1="1" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#F59E0B" stop-opacity=".9"/>

--- a/docs/public/images/post-20250914-212538-cover.svg
+++ b/docs/public/images/post-20250914-212538-cover.svg
@@ -2,8 +2,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-label="手工测试上传博文">
   <defs>
     <linearGradient id="g1" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#4F46E5"/>
-      <stop offset="1" stop-color="#6366F1"/>
+      <stop offset="0" stop-color="#A1745D"/>
+      <stop offset="1" stop-color="#C18F6D"/>
     </linearGradient>
     <linearGradient id="g2" x1="1" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#F59E0B" stop-opacity=".9"/>

--- a/docs/public/images/progress-20250914.svg
+++ b/docs/public/images/progress-20250914.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-label="Progress memo cover">
   <defs>
     <linearGradient id="g1" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#4F46E5"/>
-      <stop offset="1" stop-color="#6366F1"/>
+      <stop offset="0" stop-color="#A1745D"/>
+      <stop offset="1" stop-color="#C18F6D"/>
     </linearGradient>
     <linearGradient id="g2" x1="1" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#F59E0B" stop-opacity=".9"/>

--- a/docs/public/images/scaffold-guide-cover.svg
+++ b/docs/public/images/scaffold-guide-cover.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-label="Scaffold guide cover">
   <defs>
     <linearGradient id="g1" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#4F46E5"/>
-      <stop offset="1" stop-color="#6366F1"/>
+      <stop offset="0" stop-color="#A1745D"/>
+      <stop offset="1" stop-color="#C18F6D"/>
     </linearGradient>
     <linearGradient id="g2" x1="1" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#F59E0B" stop-opacity=".9"/>

--- a/docs/public/images/sorceress-cover.svg
+++ b/docs/public/images/sorceress-cover.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-label="D2R Sorceress">
   <defs>
     <linearGradient id="g1" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#4F46E5"/>
-      <stop offset="1" stop-color="#6366F1"/>
+      <stop offset="0" stop-color="#A1745D"/>
+      <stop offset="1" stop-color="#C18F6D"/>
     </linearGradient>
     <linearGradient id="g2" x1="1" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#F59E0B" stop-opacity=".9"/>

--- a/docs/public/images/test-cover.svg
+++ b/docs/public/images/test-cover.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
-  <rect width="1200" height="630" fill="#4F46E5"/>
+  <rect width="1200" height="630" fill="#A1745D"/>
   <text x="60" y="200" font-size="48" fill="#fff" font-weight="700">test</text>
   <text x="60" y="260" font-size="20" fill="#fff" opacity=".8">Generated at 2025/09/16 22:42:32</text>
 </svg>

--- a/docs/public/images/works/d2r-guide.svg
+++ b/docs/public/images/works/d2r-guide.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-label="D2R 职业攻略">
   <defs>
     <linearGradient id="g1" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#4F46E5"/>
-      <stop offset="1" stop-color="#6366F1"/>
+      <stop offset="0" stop-color="#A1745D"/>
+      <stop offset="1" stop-color="#C18F6D"/>
     </linearGradient>
     <linearGradient id="g2" x1="1" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#F59E0B" stop-opacity=".9"/>

--- a/scripts/new-post-local.mjs
+++ b/scripts/new-post-local.mjs
@@ -15,7 +15,7 @@ function formatDate(){ const {year,month,day,hour,minute,second}=getTZParts(); r
 function slugify(s){ return String(s||'').toLowerCase().normalize('NFKD').replace(/[\u0300-\u036f]/g,'').replace(/[^\w\s-]+/g,'').replace(/\s+/g,'-').replace(/-+/g,'-').replace(/^-|-$/g,'') }
 function escYaml(s){ return String(s).replace(/\"/g,'\\\"') }
 function ensureDir(p){ if(!fs.existsSync(p)) fs.mkdirSync(p,{recursive:true}) }
-function createCoverSVG(title, outPath){ const svg=`<?xml version="1.0" encoding="UTF-8"?>\n<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">\n  <rect width="1200" height="630" fill="#4F46E5"/>\n  <text x="60" y="200" font-size="48" fill="#fff" font-weight="700">${escYaml(title)}</text>\n  <text x="60" y="260" font-size="20" fill="#fff" opacity=".8">Generated at ${formatDate()}</text>\n</svg>`; ensureDir(path.dirname(outPath)); fs.writeFileSync(outPath,svg,'utf8') }
+function createCoverSVG(title, outPath){ const svg=`<?xml version="1.0" encoding="UTF-8"?>\n<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">\n  <rect width="1200" height="630" fill="#A1745D"/>\n  <text x="60" y="200" font-size="48" fill="#fff" font-weight="700">${escYaml(title)}</text>\n  <text x="60" y="260" font-size="20" fill="#fff" opacity=".8">Generated at ${formatDate()}</text>\n</svg>`; ensureDir(path.dirname(outPath)); fs.writeFileSync(outPath,svg,'utf8') }
 
 (function main(){
   const args=parseArgs(process.argv);


### PR DESCRIPTION
## Summary
- replace the site-wide brand palette with Pantone 17-1230 Mocha Mousse in VitePress theme variables, favicon, and build metadata
- restyle the landing hero, call-to-action buttons, and blog admin shell to use the refreshed brown gradient accents
- update SVG cover assets and the local draft generator so new artwork inherits the 2025 color of the year gradient

## Testing
- CI=1 npm run docs:build *(fails to bundle pagefind in this container, build continues without search index)*

------
https://chatgpt.com/codex/tasks/task_e_68d0c8aec3f883259711691bad1ba0f7