### PR TITLE
fix: auto-sync category navigation after admin mutations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,8 @@
 ## Project Structure & Module Organization
 The site lives under `docs/`. `.vitepress/` keeps VitePress config (`config.ts`), theme overrides, and cached Pagefind output; keep generated `dist/` out of commits. `blog/` is organised by column folders (for example `engineering/`, `creative/`) with `index.md` frontmatter driving listings. Shared static assets belong in `docs/public/`. Automation scripts reside in `scripts/`; `scripts/lib/columns.js` maps human-readable column names to directories, so update it before renaming folders. The `blog-admin/` directory powers the local editorial dashboard served by `server.mjs`.
 
+Category mutations performed through the admin API now auto-sync the navigation: `server.mjs` writes `docs/.vitepress/categories.nav.json` and patches the `/* ADMIN NAV START */ … /* ADMIN NAV END */` block via `syncCategoryNavArtifacts`/`safeSyncCategoryNav`. Keep those helpers in lockstep with the standalone `/api/categories/nav-sync` endpoint when adjusting the workflow.
+
 The `guides/` column purposely omits an `index.md`; the main site navigation item “攻略” is wired in `docs/.vitepress/config.ts` to redirect to the latest article whose frontmatter declares `categories: [职业攻略]`. Avoid recreating the index page or changing that navigation link unless you also update the helper functions in `config.ts`.
 
 ## Build, Test, and Development Commands

--- a/blog-admin/public/categories.js
+++ b/blog-admin/public/categories.js
@@ -8,6 +8,20 @@ const ISSUE_LABELS={
   'unused':'未被引用'
 };
 const STATE={ items:[], orphans:[] };
+function toastWithNavSync(message, navSync, ok=true){
+  const base=String(message||'').trim()||'操作完成';
+  if(!navSync){ toast(base.slice(0,400), ok); return; }
+  if(navSync.ok){
+    const touches=[];
+    if(navSync.json) touches.push(navSync.json);
+    if(navSync.config) touches.push(navSync.config);
+    const suffix=touches.length?`（${touches.join('、')}）`:'';
+    toast(`${base}；导航已同步${suffix}`.slice(0,400), ok);
+  }else{
+    const err=String(navSync.error||'未知错误');
+    toast(`${base}；导航同步失败：${err}`.slice(0,400), false);
+  }
+}
 
 function fmtTime(iso){ if(!iso) return ''; try{ return new Date(iso).toLocaleString(); }catch{ return ''; } }
 function toVSCodeUri(abs){ if(!abs) return ''; const norm=abs.replace(/\\/g,'/'); const win=norm.replace(/^([A-Za-z]):/, '/$1:'); return 'vscode://file'+encodeURI(win); }
@@ -63,9 +77,10 @@ async function handleEdit(dir){
   if(item.title !== title){ rewriteFlag = confirm('是否同步重写所有文章中的分类引用？（取消则跳过批量重写）'); }
   const payload={ dir:item.dir, title, menuLabel, nextDir, ensureDir, rewrite: rewriteFlag };
   const res = await api('/api/categories/update','POST', payload);
-  if(res.dirMove?.to){ toast(`分类已更新，目录已移动到 ${res.dirMove.to}`); }
-  else if(res.rewrite?.summary){ toast(res.rewrite.summary); }
-  else toast('分类已更新');
+  let msg='分类已更新';
+  if(res.dirMove?.to){ msg=`分类已更新，目录已移动到 ${res.dirMove.to}`; }
+  else if(res.rewrite?.summary){ msg=res.rewrite.summary; }
+  toastWithNavSync(msg, res.navSync, true);
 }
 
 function renderCategories(list){
@@ -114,21 +129,21 @@ function renderCategories(list){
         if(btn.dataset.act==='edit'){
           await handleEdit(dir);
         }else if(btn.dataset.act==='toggle-publish'){
-          await api('/api/categories/toggle','POST',{ dir, field:'publish', value: btn.dataset.value==='true' });
-          toast('已更新内容上架状态');
+          const res = await api('/api/categories/toggle','POST',{ dir, field:'publish', value: btn.dataset.value==='true' });
+          toastWithNavSync('已更新内容上架状态', res.navSync, true);
         }else if(btn.dataset.act==='toggle-menu'){
-          await api('/api/categories/toggle','POST',{ dir, field:'menuEnabled', value: btn.dataset.value==='true' });
-          toast('已更新菜单上架状态');
+          const res = await api('/api/categories/toggle','POST',{ dir, field:'menuEnabled', value: btn.dataset.value==='true' });
+          toastWithNavSync('已更新菜单上架状态', res.navSync, true);
         }else if(btn.dataset.act==='delete'){
           if(!dir){ toast('缺少目录标识',false); return; }
           if(!confirm('确认删除该分类？（不会移除目录）')) return;
-          await api('/api/categories/delete','POST',{ dir });
-          toast('已删除分类');
+          const res = await api('/api/categories/delete','POST',{ dir });
+          toastWithNavSync('已删除分类', res.navSync, true);
         }else if(btn.dataset.act==='delete-hard'){
           if(!dir){ toast('缺少目录标识',false); return; }
           if(!confirm('确认删除该分类并尝试移除目录？')) return;
-          await api('/api/categories/delete','POST',{ dir, hard:true });
-          toast('已删除分类，目录如为空将被移除');
+          const res = await api('/api/categories/delete','POST',{ dir, hard:true });
+          toastWithNavSync('已删除分类，目录如为空将被移除', res.navSync, true);
         }else if(btn.dataset.act==='rewrite'){
           await runCategoryRewrite(title || dir);
         }else if(btn.dataset.act==='open'){
@@ -239,8 +254,8 @@ async function main(){
     if(!payload.title){ toast('请填写分类名称', false); return; }
     if(!payload.dir){ toast('请填写目录', false); return; }
     try{
-      await api('/api/categories/create','POST', payload);
-      toast('分类已创建');
+      const res = await api('/api/categories/create','POST', payload);
+      toastWithNavSync('分类已创建', res.navSync, true);
       resetCreateForm();
       await refresh();
     }catch(e){ toast((e.detail?.err||e.detail?.out||e.message||'创建失败').slice(0,400), false); }


### PR DESCRIPTION
## Summary
- ensure the admin API regenerates `categories.nav.json` and patches the VitePress config after every category mutation via a shared sync helper
- surface the nav sync outcome in the category management UI so editors see whether menu changes hit the top navigation immediately
- document the new workflow in `AGENTS.md` and refresh the development progress log

## Testing
- `CI=1 npm run docs:build`


------
https://chatgpt.com/codex/tasks/task_e_68d188d5825083259596dcf405c62c93