### PR TITLE
fix(theme): load blog texture via static import

### DIFF
--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,12 +1,8 @@
 import Theme from '@sugarat/theme'
+import textureUrl from '@sugarat-theme-styles/bg.png?url'
 import type { EnhanceAppContext, PageData, Theme as VitePressTheme } from 'vitepress'
 import { inBrowser } from 'vitepress'
 import './custom.css'
-
-const blogBackgroundTexture = new URL(
-  '@sugarat-theme-styles/bg.png',
-  import.meta.url
-).href
 
 const extendedTheme: VitePressTheme = {
   ...Theme,
@@ -15,7 +11,7 @@ const extendedTheme: VitePressTheme = {
     if (inBrowser) {
       document.documentElement.style.setProperty(
         '--blog-bg-texture',
-        `url(${blogBackgroundTexture})`
+        `url(${textureUrl})`
       )
       setupCategoryNavPersistence(ctx)
     }


### PR DESCRIPTION
## Summary
- load the blog background texture via a static import so Vite rewrites it to the hashed asset at runtime

## Testing
- CI=1 npm run docs:dev -- --host 0.0.0.0 *(fails to auto-open a browser because xdg-open is unavailable in the container, but the dev server starts)*
- CI=1 npm run docs:build

------
https://chatgpt.com/codex/tasks/task_e_68d6589d868c83259ad1592eee07405d