### PR TITLE
fix(docs): align blog theme selectors

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -133,7 +133,7 @@ html.dark {
 }
 
 /* 文档页侧栏与正文卡片一致 */
-.blog-theme-layout #VPContent:not(.is-home) aside.VPSidebar {
+.blog-theme-layout:has(.VPContent:not(.is-home)) .VPSidebar {
   display: flex;
   flex-direction: column;
   gap: 18px;
@@ -142,19 +142,19 @@ html.dark {
   border: none;
 }
 
-.blog-theme-layout #VPContent:not(.is-home) aside.VPSidebar .curtain {
-  background: var(--nav-bgc);
+.blog-theme-layout:has(.VPContent:not(.is-home)) .VPSidebar .curtain {
+  background: transparent;
   border-radius: 16px;
   padding: 28px 24px;
   box-shadow: none;
-  border: 1px solid rgba(var(--bg-gradient-home), 0.25);
+  border: none;
   margin-bottom: 8px;
 }
 
 /* 文章目录与正文去除卡片外框 */
-.blog-theme-layout #VPContent:not(.is-home) aside.VPSidebar .sidebar,
-.blog-theme-layout #VPContent:not(.is-home) .VPDoc .vp-doc,
-.blog-theme-layout #VPContent:not(.is-home) .VPDoc .outline {
+.blog-theme-layout:has(.VPContent:not(.is-home)) .VPSidebar .sidebar,
+.blog-theme-layout .VPContent:not(.is-home) .VPDoc .vp-doc,
+.blog-theme-layout .VPContent:not(.is-home) .VPDoc .outline {
   background: transparent;
   border: none;
   box-shadow: none;
@@ -163,7 +163,7 @@ html.dark {
 }
 
 /* 博客文章页背景与博客首页保持一致 */
-.blog-theme-layout #VPContent:not(.is-home) {
+.blog-theme-layout .VPContent:not(.is-home) {
   position: relative;
   min-height: 100vh;
   background-image: radial-gradient(
@@ -173,7 +173,7 @@ html.dark {
     );
 }
 
-.blog-theme-layout #VPContent:not(.is-home)::before {
+.blog-theme-layout .VPContent:not(.is-home)::before {
   content: '';
   position: fixed;
   inset: 0;
@@ -183,9 +183,9 @@ html.dark {
   pointer-events: none;
 }
 
-.blog-theme-layout #VPContent:not(.is-home) .VPDoc,
-.blog-theme-layout #VPContent:not(.is-home) .VPDoc main,
-.blog-theme-layout #VPContent:not(.is-home) .VPSidebar,
-.blog-theme-layout #VPContent:not(.is-home) .VPDoc aside {
+.blog-theme-layout .VPContent:not(.is-home) .VPDoc,
+.blog-theme-layout .VPContent:not(.is-home) .VPDoc main,
+.blog-theme-layout:has(.VPContent:not(.is-home)) .VPSidebar,
+.blog-theme-layout .VPContent:not(.is-home) .VPDoc aside {
   background: transparent;
 }


### PR DESCRIPTION
## Summary
- update the blog layout selectors to match the current VPSidebar/VPContent structure so non-home routes inherit the transparent styling
- ensure the sidebar curtain uses a transparent background alongside VPDoc/outline rules that follow the VPContent tree

## Testing
- PATH=$PWD/tmp-bin:$PATH npm run docs:dev -- --host 0.0.0.0

------
https://chatgpt.com/codex/tasks/task_e_68d658d6f23483258fad1e8b923a2f6b