### PR TITLE
fix(theme): load blog texture via Vite asset import

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -191,7 +191,7 @@ export default defineConfig({
     plugins: [faviconIcoFallback(), overrideSugaratComponents()],
     resolve: {
       alias: {
-        '@sugarat-theme-styles': path.resolve(process.cwd(), 'node_modules/@sugarat/theme/src/styles'),
+        '@sugarat/theme/src/styles': path.resolve(process.cwd(), 'node_modules/@sugarat/theme/src/styles'),
         '@sugarat/theme/src/components/BlogItem.vue': path.resolve(process.cwd(), 'docs/.vitepress/theme/BlogItem.vue'),
         '@sugarat/theme/src/components/BlogArticleAnalyze.vue': path.resolve(process.cwd(), 'docs/.vitepress/theme/BlogArticleAnalyze.vue'),
         '@sugarat/theme/src/components/BlogHotArticle.vue': path.resolve(process.cwd(), 'docs/.vitepress/theme/BlogHotArticle.vue'),

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -4,7 +4,6 @@
   --vp-c-brand-2: #C18F6D;
   --vp-c-brand-3: #8C5E45;
   --xl-accent: #F59E0B; /* amber */
-  --blog-bg-texture: none;
 
   /* 卡片与阴影 */
   --xl-radius: 14px;
@@ -178,6 +177,7 @@ html.dark {
   position: fixed;
   inset: 0;
   z-index: -1;
+  background-image: var(--blog-bg-texture, none);
   background-repeat: repeat;
   min-height: 100%;
   pointer-events: none;

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,5 +1,5 @@
 import Theme from '@sugarat/theme'
-import textureUrl from '@sugarat-theme-styles/bg.png?url'
+import textureUrl from '@sugarat/theme/src/styles/bg.png?url'
 import type { EnhanceAppContext, PageData, Theme as VitePressTheme } from 'vitepress'
 import { inBrowser } from 'vitepress'
 import './custom.css'


### PR DESCRIPTION
## Summary
- import the sugarat background texture via Vite's `?url` helper and expose the package styles under a direct alias
- drive the blog background pseudo-element from the texture variable with a `none` fallback when unset

## Testing
- timeout 5 env BROWSER=none npm run docs:dev -- --host 0.0.0.0 --clearScreen false
- CI=1 npm run docs:build


------
https://chatgpt.com/codex/tasks/task_e_68d661751e488325a4d5eb4ed6eb4d1e