### PR TITLE
style(blog): add vertical divider for doc aside

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -205,3 +205,32 @@ html.dark {
 .blog-theme-layout .VPContent:not(.is-home) .VPDoc aside {
   background: transparent;
 }
+
+@media (min-width: 1280px) {
+  .blog-theme-layout #VPContent:not(.is-home) .VPDoc .aside {
+    position: relative;
+  }
+
+  .blog-theme-layout #VPContent:not(.is-home) .VPDoc .aside::before {
+    content: '';
+    position: absolute;
+    top: calc(
+      var(--vp-nav-height) +
+      var(--vp-layout-top-height, 0px) +
+      var(--vp-doc-top-height, 0px)
+    );
+    left: 0;
+    width: 1px;
+    height: calc(
+      100vh -
+        (
+          var(--vp-nav-height) +
+          var(--vp-layout-top-height, 0px) +
+          var(--vp-doc-top-height, 0px)
+        )
+    );
+    display: block;
+    background: linear-gradient(var(--vp-c-gutter), var(--vp-c-divider));
+    pointer-events: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a fixed-height divider for the blog outline aside so the vertical rule lines up with the nav baseline

## Testing
- not run (css-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d666ba04e483258c7d6ab4a30560f7