### PR TITLE
fix(theme): align outline divider with offset

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -217,7 +217,8 @@ html.dark {
     top: calc(
       var(--vp-nav-height) +
       var(--vp-layout-top-height, 0px) +
-      var(--vp-doc-top-height, 0px)
+      var(--vp-doc-top-height, 0px) +
+      48px
     );
     left: 0;
     width: 1px;
@@ -226,7 +227,8 @@ html.dark {
         (
           var(--vp-nav-height) +
           var(--vp-layout-top-height, 0px) +
-          var(--vp-doc-top-height, 0px)
+          var(--vp-doc-top-height, 0px) +
+          48px
         )
     );
     display: block;


### PR DESCRIPTION
## Summary
- adjust the table-of-contents divider positioning to include the extra 48px offset
- update the divider height calculation so it only spans the outline region

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d693729cec8325952e0b8e55a632f9