### PR TITLE
fix(theme): align aside divider with content

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -222,17 +222,16 @@ html.dark {
     );
     left: 0;
     width: 1px;
-    height: calc(
-      100vh -
-        (
-          var(--vp-nav-height) +
-          var(--vp-layout-top-height, 0px) +
-          var(--vp-doc-top-height, 0px) +
-          48px
-        )
-    );
+    bottom: 32px;
     display: block;
     background: linear-gradient(var(--vp-c-gutter), var(--vp-c-divider));
     pointer-events: none;
+    transform: translateX(-32px);
+  }
+
+  .blog-theme-layout #VPContent:not(.is-home) .VPDoc .aside.left-aside::before {
+    left: auto;
+    right: 0;
+    transform: translateX(32px);
   }
 }


### PR DESCRIPTION
## Summary
- update the doc aside divider to span the same vertical space as the aside content with a bottom curtain gap
- offset the divider horizontally so it aligns with the outline column and handle the mirrored left-aside layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d697a11a8c8325aa865ec2e1253693