### PR TITLE
fix(theme): center doc outline divider

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -226,12 +226,12 @@ html.dark {
     display: block;
     background: linear-gradient(var(--vp-c-gutter), var(--vp-c-divider));
     pointer-events: none;
-    transform: translateX(-32px);
+    transform: translateX(-64px);
   }
 
   .blog-theme-layout #VPContent:not(.is-home) .VPDoc .aside.left-aside::before {
     left: auto;
     right: 0;
-    transform: translateX(32px);
+    transform: translateX(64px);
   }
 }


### PR DESCRIPTION
## Summary
- adjust the doc aside divider offsets to sit within the column gap on wide layouts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d69f1f2d4c8325a1db392dc0d4aa07