### PR TITLE
fix(theme): remove doc outline divider

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -211,27 +211,4 @@ html.dark {
     position: relative;
   }
 
-  .blog-theme-layout #VPContent:not(.is-home) .VPDoc .aside::before {
-    content: '';
-    position: absolute;
-    top: calc(
-      var(--vp-nav-height) +
-      var(--vp-layout-top-height, 0px) +
-      var(--vp-doc-top-height, 0px) +
-      48px
-    );
-    left: 0;
-    width: 1px;
-    bottom: 32px;
-    display: block;
-    background: linear-gradient(var(--vp-c-gutter), var(--vp-c-divider));
-    pointer-events: none;
-    transform: translateX(-32px);
-  }
-
-  .blog-theme-layout #VPContent:not(.is-home) .VPDoc .aside.left-aside::before {
-    left: auto;
-    right: 0;
-    transform: translateX(32px);
-  }
 }


### PR DESCRIPTION
## Summary
- remove the pseudo-element that drew the doc outline divider on wide layouts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d69f1f2d4c8325a1db392dc0d4aa07