### PR TITLE
fix(theme): keep outline divider visible on small screens

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -159,6 +159,18 @@ html.dark {
   box-shadow: none;
   padding: 0;
   border-radius: 0;
+  position: relative;
+}
+
+.blog-theme-layout .VPContent:not(.is-home) .VPDoc .outline::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: -24px;
+  width: 1px;
+  background: var(--vp-c-divider);
+  pointer-events: none;
 }
 
 /* 博客侧边栏导航分隔线与背景对齐 */


### PR DESCRIPTION
## Summary
- keep the blog outline container positioned relative so pseudo elements can render
- render the outline divider pseudo element by default so it shows up on narrower viewports

## Testing
- CI=1 npm run docs:build

------
https://chatgpt.com/codex/tasks/task_e_68d6aaa1d96c83258473c202d23de97f