### PR TITLE
fix: adjust blog outline divider spacing

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -167,10 +167,16 @@ html.dark {
   position: absolute;
   top: 0;
   bottom: 0;
-  right: -24px;
+  right: 0;
   width: 1px;
   background: var(--vp-c-divider);
   pointer-events: none;
+}
+
+@media (min-width: 1200px) {
+  .blog-theme-layout .VPContent:not(.is-home) .VPDoc .outline::after {
+    right: 8px;
+  }
 }
 
 /* 博客侧边栏导航分隔线与背景对齐 */


### PR DESCRIPTION
## Summary
- reset the outline divider offset so the rule stays inside the table of contents container
- add a wide-viewport media query to keep comfortable spacing without clipping

## Testing
- CI=1 npm run docs:build

------
https://chatgpt.com/codex/tasks/task_e_68d6aeb92c8c83258f2c1b208ce5dd58