### PR TITLE
fix(docs): align outline divider with aside container

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -153,16 +153,20 @@ html.dark {
 /* 文章目录与正文去除卡片外框 */
 .blog-theme-layout:has(.VPContent:not(.is-home)) .VPSidebar .sidebar,
 .blog-theme-layout .VPContent:not(.is-home) .VPDoc .vp-doc,
-.blog-theme-layout .VPContent:not(.is-home) .VPDoc .outline {
+.blog-theme-layout .VPContent:not(.is-home) .VPDoc .outline,
+.blog-theme-layout .VPContent:not(.is-home) .VPDocAsideOutline .content {
   background: transparent;
   border: none;
   box-shadow: none;
   padding: 0;
   border-radius: 0;
+}
+
+.blog-theme-layout .VPContent:not(.is-home) .VPDocAsideOutline .content {
   position: relative;
 }
 
-.blog-theme-layout .VPContent:not(.is-home) .VPDoc .outline::after {
+.blog-theme-layout .VPContent:not(.is-home) .VPDocAsideOutline .content::after {
   content: '';
   position: absolute;
   top: 0;
@@ -174,7 +178,7 @@ html.dark {
 }
 
 @media (min-width: 1200px) {
-  .blog-theme-layout .VPContent:not(.is-home) .VPDoc .outline::after {
+  .blog-theme-layout .VPContent:not(.is-home) .VPDocAsideOutline .content::after {
     right: 8px;
   }
 }


### PR DESCRIPTION
## Summary
- apply the outline chrome reset to both the dropdown and aside container
- move the divider pseudo-element to the aside content so it renders inside the panel

## Testing
- npm run docs:dev -- --host 0.0.0.0 --port 4173 --no-open

------
https://chatgpt.com/codex/tasks/task_e_68d6b36ea9148325b01599a9e354ed44