### PR TITLE
fix: align catalog heading padding

### DIFF
--- a/docs/.vitepress/theme/BlogRecommendArticle.vue
+++ b/docs/.vitepress/theme/BlogRecommendArticle.vue
@@ -113,6 +113,7 @@ function handleNavigate(target: { href: string }) {
 
 .catalog__title {
   margin: 0 0 16px;
+  padding-left: calc(2ch + 12px);
   font-size: 18px;
   font-weight: 600;
 }


### PR DESCRIPTION
## Summary
- add left padding to the catalog heading so it lines up with the catalog entries

## Testing
- node node_modules/vitepress/bin/vitepress.js dev docs --host 0.0.0.0 --port 5173

------
https://chatgpt.com/codex/tasks/task_e_68d7f0343fe883258c5a9e634878ca70