### PR TITLE
fix: ensure Pagefind stub assets when indexing is skipped

### DIFF
--- a/scripts/run-pagefind.mjs
+++ b/scripts/run-pagefind.mjs
@@ -1,6 +1,23 @@
 #!/usr/bin/env node
 import { spawnSync } from 'node:child_process'
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
 import process from 'node:process'
+
+const ensurePagefindStub = () => {
+  const pagefindDir = path.join(siteDir, 'pagefind')
+  mkdirSync(pagefindDir, { recursive: true })
+
+  const jsPath = path.join(pagefindDir, 'pagefind.js')
+  if (!existsSync(jsPath)) {
+    writeFileSync(jsPath, "export const init = () => {}\n")
+  }
+
+  const cssPath = path.join(pagefindDir, 'pagefind.css')
+  if (!existsSync(cssPath)) {
+    writeFileSync(cssPath, '')
+  }
+}
 
 const [, , siteArg, selectorsArg, forceLanguageArg] = process.argv
 const siteDir = siteArg && siteArg.trim() ? siteArg : 'docs/.vitepress/dist'
@@ -11,6 +28,7 @@ const disable = String(process.env.PAGEFIND_DISABLE ?? '').toLowerCase()
 const shouldSkip = disable === '1' || disable === 'true' || process.platform === 'win32'
 
 if (shouldSkip) {
+  ensurePagefindStub()
   console.log('[pagefind] Skip index generation for this environment.')
   process.exit(0)
 }
@@ -42,6 +60,7 @@ if (result.status && result.status !== 0) {
   const combined = `${result.stdout ?? ''}${result.stderr ?? ''}`
   const unsupported = /not yet a supported architecture/i.test(combined) || /Failed to install either of \[pagefind_extended, pagefind\]/i.test(combined)
   if (unsupported) {
+    ensurePagefindStub()
     console.warn('[pagefind] Binary unavailable; continuing without search index.')
     process.exit(0)
   }


### PR DESCRIPTION
## Summary
- ensure the Pagefind runner creates stub JS/CSS assets when indexing is skipped
- reuse the stub helper when the Pagefind binary is unavailable so builds still ship the bundle

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7f5e9c66c8325bbc0d7136a95ad4e