### PR TITLE
fix: provide inline mail icon for social links

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -98,6 +98,10 @@ if (pagefindForceLanguage) {
   pagefindSearch.forceLanguage = pagefindForceLanguage
 }
 
+const mailIcon = {
+  svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4h16a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2z"/><path d="m22 6-10 7L2 6"/></svg>'
+} as const
+
 const blogTheme = getThemeConfig({
   timeZone: 0,
   author: '小凌',
@@ -110,7 +114,7 @@ const blogTheme = getThemeConfig({
   },
   socialLinks: [
     { icon: 'github', link: 'https://github.com/lxlcool3000' },
-    { icon: 'email', link: 'mailto:coollxl92@gmail.com' }
+    { icon: mailIcon, link: 'mailto:coollxl92@gmail.com' }
   ],
   search: pagefindSearch,
   hotArticle: false,
@@ -133,7 +137,7 @@ export default defineConfig({
     logo: '/avatar-avatar.png',
     socialLinks: [
       { icon: 'github', link: 'https://github.com/lxlcool3000' },
-      { icon: 'mail', link: 'mailto:coollxl92@gmail.com' }
+      { icon: mailIcon, link: 'mailto:coollxl92@gmail.com' }
     ],
     nav: [
       { text: '博客', link: '/blog/' },


### PR DESCRIPTION
## Summary
- add a reusable inline SVG mail icon for VitePress configuration
- update navbar and home social links to reference the shared icon

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7f725790c8325a971b6d5623d7025