### PR TITLE
fix: annotate mail icon config

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -98,7 +98,14 @@ if (pagefindForceLanguage) {
   pagefindSearch.forceLanguage = pagefindForceLanguage
 }
 
-const mailIcon = {
+const mailIcon: { svg: string } = {
+  svg: [
+    '<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">',
+    '  <path fill="currentColor" d="M3 4h18a1 1 0 0 1 1 1v14a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1Zm0 2v.217l9 5.4 9-5.4V6ZM21 8.783l-8.553 5.13a1 1 0 0 1-1.894 0L3 8.783V19H21Z" />',
+    '</svg>'
+  ].join('\n')
+}
+
 const blogTheme = getThemeConfig({
   timeZone: 0,
   author: '小凌',


### PR DESCRIPTION
## Summary
- annotate the mail icon configuration with an explicit `{ svg: string }` type instead of relying on `satisfies`
- inline the social mail icon SVG markup via a newline-joined string to keep VitePress happy

## Testing
- npm run docs:build

------
https://chatgpt.com/codex/tasks/task_e_68d80455b52083258fb644872db4fc36