### PR TITLE
fix: align blog info card with post list

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -131,6 +131,17 @@ html.dark {
   padding: 0;
 }
 
+/* 博客首页头像卡片顶部对齐列表 */
+.blog-theme-layout .content-wrapper .blog-info-wrapper {
+  top: var(--vp-nav-height);
+}
+
+@media (max-width: 959.98px) {
+  .blog-theme-layout .content-wrapper .blog-info-wrapper {
+    top: 20px;
+  }
+}
+
 /* 文档页侧栏与正文卡片一致 */
 .blog-theme-layout:has(.VPContent:not(.is-home)) .VPSidebar {
   display: flex;


### PR DESCRIPTION
## Summary
- adjust the blog info wrapper sticky offset so the avatar card aligns with the post list
- add a tablet breakpoint reset to keep spacing consistent below 960px

## Testing
- npm run docs:dev -- --host 0.0.0.0 --port 5173

------
https://chatgpt.com/codex/tasks/task_e_68d80a1c4fd8832599213b42e2e1f4fb