### PR TITLE
fix: align blog info card offset

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -131,6 +131,27 @@ html.dark {
   padding: 0;
 }
 
+/* 博客首页头像卡片顶部对齐列表 */
+.blog-theme-layout {
+  --blog-info-top-gap: 24px;
+}
+
+.blog-theme-layout .content-wrapper .blog-info-wrapper {
+  top: calc(var(--vp-nav-height) + var(--blog-info-top-gap));
+}
+
+@media (min-width: 960px) {
+  .blog-theme-layout .content-wrapper .blog-list-wrapper {
+    padding-top: var(--blog-info-top-gap);
+  }
+}
+
+@media (max-width: 959.98px) {
+  .blog-theme-layout {
+    --blog-info-top-gap: 20px;
+  }
+}
+
 /* 文档页侧栏与正文卡片一致 */
 .blog-theme-layout:has(.VPContent:not(.is-home)) .VPSidebar {
   display: flex;


### PR DESCRIPTION
## Summary
- ensure the blog info card sticks below the nav by combining the nav height with a reusable gap variable
- match the blog list padding to the new gap and retain the 20px mobile spacing so the columns stay aligned

## Testing
- npm run docs:dev -- --host 0.0.0.0 --port 5173

------
https://chatgpt.com/codex/tasks/task_e_68d80a1c4fd8832599213b42e2e1f4fb