### PR TITLE
fix: align blog list with avatar card offset

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -131,6 +131,31 @@ html.dark {
   padding: 0;
 }
 
+/* 博客首页头像卡片与列表联动间距 */
+.blog-theme-layout .content-wrapper {
+  --blog-info-top-gap: 16px;
+  --blog-info-top-offset: calc(var(--vp-nav-height) + var(--blog-info-top-gap));
+}
+
+.blog-theme-layout .content-wrapper .blog-info-wrapper {
+  top: var(--blog-info-top-offset);
+}
+
+.blog-theme-layout .content-wrapper .blog-list-wrapper {
+  padding-top: var(--blog-info-top-gap);
+}
+
+@media (max-width: 959.98px) {
+  .blog-theme-layout .content-wrapper {
+    --blog-info-top-gap: 0px;
+    --blog-info-top-offset: 20px;
+  }
+
+  .blog-theme-layout .content-wrapper .blog-list-wrapper {
+    padding-top: 0;
+  }
+}
+
 /* 文档页侧栏与正文卡片一致 */
 .blog-theme-layout:has(.VPContent:not(.is-home)) .VPSidebar {
   display: flex;


### PR DESCRIPTION
## Summary
- share a `--blog-info-top-offset` variable between the blog info sidebar and list wrapper so they sit at the same height
- add a consistent 16px gap below the nav on desktop while keeping the 20px sticky fallback on tablets and smaller

## Testing
- npm run docs:dev -- --host 0.0.0.0 --port 5173

------
https://chatgpt.com/codex/tasks/task_e_68d80a1c4fd8832599213b42e2e1f4fb