### PR TITLE
fix: add spacing beneath blog nav

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -131,7 +131,20 @@ html.dark {
   padding: 0;
 }
 
+/* 博客首页头像卡片与列表联动间距 */
+@media (min-width: 960px) {
+  .blog-theme-layout .content-wrapper .blog-info-wrapper {
+    top: calc(var(--vp-nav-height) + 24px);
+  }
 
+  .blog-theme-layout .content-wrapper .blog-list-wrapper {
+    padding-top: 24px;
+  }
+}
+
+@media (max-width: 959.98px) {
+  .blog-theme-layout .content-wrapper .blog-info-wrapper {
+    top: 20px;
   }
 }
 


### PR DESCRIPTION
## Summary
- increase the sticky avatar card offset to sit nav height plus 24px on desktop
- add equivalent padding to the blog list column so the first post stays aligned with the avatar card

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d81bdef81483258741a50e6e84b227