### PR TITLE
fix: debounce blog restart when markdown files are removed

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'vitepress'
+import type { PluginOption } from 'vite'
 import fs from 'node:fs'
 import path from 'node:path'
 
@@ -11,6 +12,7 @@ import {
 } from '../../scripts/lib/frontmatter.js'
 
 const deployBase = process.env.DEPLOY_BASE || '/'
+const docsRoot = path.resolve(process.cwd(), 'docs')
 
 // @sugarat/theme-shared requires a positive concurrency value; some hosts
 // (including the Codex sandbox) report 0 CPUs, so guard with a sane default.
@@ -60,10 +62,15 @@ function buildCategoryNavItems(navConfig: CategoryNavItem[]) {
     })
     .map((item) => {
       const title = String(item?.category || item?.text || '').trim()
-      const fallbackLink = normalizeLink(String(item?.fallback || item?.link || '/blog/')) || '/blog/'
-      const precomputed = normalizeLink(item?.latestLink || '')
-      const resolved = precomputed || (title ? resolveLatestCategoryArticle(title) : '')
-      const link = resolved || fallbackLink
+      const fallbackSource = normalizeLink(String(item?.fallback || item?.link || '/blog/')) || '/blog/'
+      const fallbackLink = ensureExistingRoute(fallbackSource)
+      const precomputed = ensureExistingRoute(item?.latestLink || '', fallbackLink)
+      const resolved = ensureExistingRoute(
+        title ? resolveLatestCategoryArticle(title) : '',
+        precomputed,
+        fallbackLink
+      )
+      const link = ensureExistingRoute(resolved, fallbackLink)
       return {
         text: item?.text || title || '分类',
         link,
@@ -125,6 +132,9 @@ const blogTheme = getThemeConfig({
   homeTags: false,
   recommend: { showDate: true }
 } as any)
+const blog = blogTheme?.themeConfig?.blog as
+  | { pagesData?: Array<{ route?: string }> }
+  | undefined
 
 export default defineConfig({
   extends: blogTheme,
@@ -152,7 +162,12 @@ export default defineConfig({
     outline: { label: '本页导航', level: 'deep' }
   },
   vite: {
-    plugins: [faviconIcoFallback(), overrideSugaratComponents(), adminNavWatcherPlugin()],
+    plugins: [
+      faviconIcoFallback(),
+      overrideSugaratComponents(),
+      adminNavWatcherPlugin(),
+      blogUnlinkRestartPlugin()
+    ],
     resolve: {
       alias: {
         '@sugarat/theme/src/styles': path.resolve(process.cwd(), 'node_modules/@sugarat/theme/src/styles'),
@@ -228,9 +243,73 @@ function adminNavWatcherPlugin() {
 }
 
 
+function blogUnlinkRestartPlugin(): PluginOption {
+  return {
+    name: 'blog-unlink-restart',
+    apply: 'serve' as const,
+    configureServer(server) {
+      const docsRoot = path.resolve(process.cwd(), 'docs')
+      let restartTimer: NodeJS.Timeout | null = null
+
+      const toRoute = (input: string) => {
+        const cleaned = input.replace(/^\/+/, '')
+        if (!cleaned) return ''
+        return '/' + cleaned.replace(/\.md$/, '')
+      }
+
+      const queueRestart = () => {
+        if (restartTimer) clearTimeout(restartTimer)
+        restartTimer = setTimeout(async () => {
+          restartTimer = null
+          try {
+            await server.restart()
+          } catch (err) {
+            console.warn('[vite] failed to restart after blog unlink', err)
+          } finally {
+            try {
+              server.ws.send({ type: 'full-reload' })
+            } catch {}
+          }
+        }, 200)
+      }
+
+      const handleUnlink = (file?: string) => {
+        if (!file || !file.endsWith('.md')) return
+        const relative = path.relative(docsRoot, file).replace(/\\/g, '/')
+        if (!relative || relative.startsWith('..') || !relative.startsWith('blog/')) return
+
+        const route = toRoute(relative)
+        if (!route) return
+
+        const pagesData = Array.isArray(blog?.pagesData) ? blog.pagesData : null
+        if (pagesData?.length) {
+          for (let index = pagesData.length - 1; index >= 0; index -= 1) {
+            const existing = toRoute(String(pagesData[index]?.route || ''))
+            if (existing === route) {
+              pagesData.splice(index, 1)
+            }
+          }
+        }
+
+        queueRestart()
+      }
+
+      server.watcher.on('unlink', handleUnlink)
+      server.httpServer?.once('close', () => {
+        server.watcher.off('unlink', handleUnlink)
+        if (restartTimer) {
+          clearTimeout(restartTimer)
+          restartTimer = null
+        }
+      })
+    }
+  }
+}
+
+
 function resolveLatestCategoryArticle(category: string) {
   if (!category) return '/blog/'
-  const blogRoot = path.resolve(process.cwd(), 'docs/blog')
+  const blogRoot = path.join(docsRoot, 'blog')
   const stack: string[] = [blogRoot]
   let latest: { time: number; link: string } | null = null
   while (stack.length) {
@@ -268,7 +347,6 @@ function resolveLatestCategoryArticle(category: string) {
 }
 
 function buildRouteFromPath(filePath: string) {
-  const docsRoot = path.resolve(process.cwd(), 'docs')
   let relative = path.relative(docsRoot, filePath).replace(/\\/g, '/')
   if (!relative) return ''
   if (relative.endsWith('index.md')) {
@@ -278,6 +356,32 @@ function buildRouteFromPath(filePath: string) {
   }
   if (!relative.startsWith('/')) relative = `/${relative}`
   return relative || ''
+}
+
+function resolveFileForRoute(route: string) {
+  if (!route) return null
+  let normalized = normalizeLink(route)
+  if (!normalized) return null
+  normalized = normalized.replace(/[?#].*$/, '').replace(/\/+/g, '/')
+  let relative = normalized.slice(1)
+  if (relative.endsWith('/')) relative = relative.slice(0, -1)
+  const directPath = path.join(docsRoot, `${relative}.md`)
+  if (fs.existsSync(directPath)) return directPath
+  const indexPath = path.join(docsRoot, relative, 'index.md')
+  if (fs.existsSync(indexPath)) return indexPath
+  return null
+}
+
+function ensureExistingRoute(candidate: string, ...fallbacks: string[]): string {
+  const options = [candidate, ...fallbacks, '/blog/']
+  for (const option of options) {
+    const normalized = normalizeLink(option || '')
+    if (!normalized) continue
+    if (resolveFileForRoute(normalized)) {
+      return normalized
+    }
+  }
+  return '/blog/'
 }
 
 function faviconIcoFallback() {


### PR DESCRIPTION
## Summary
- adjust the dev-only blog unlink restart plugin to normalize routes via a shared helper before pruning cached page data
- ensure deleted blog markdown files always trigger a debounced server restart and full reload while cleaning up watchers on shutdown

## Testing
- CI=1 npm run docs:build

------
https://chatgpt.com/codex/tasks/task_e_68d9545dea9c8325a357141eca93ef4b