### PR TITLE
fix: restore category fallback link handling

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -61,6 +61,22 @@ function buildCategoryNavItems(navConfig: CategoryNavItem[]) {
       return String(a?.text || a?.category || '').localeCompare(String(b?.text || b?.category || ''))
     })
     .map((item) => {
+      const {
+        text: rawText,
+        category: rawCategory,
+        dir: rawDir,
+        link: rawLink,
+        fallback: rawFallback,
+        menuOrder: rawMenuOrder,
+        latestLink: rawLatestLink,
+        latestUpdatedAt: rawLatestUpdatedAt,
+        latestTitle: rawLatestTitle,
+        postCount: rawPostCount,
+        publishedCount: rawPublishedCount
+      } = item || ({} as CategoryNavItem)
+
+      const title = String(rawText || rawCategory || '').trim()
+      const fallbackSource = String(rawFallback || rawLink || '')
       const fallbackLink = ensureExistingRoute(fallbackSource)
       const precomputed = ensureExistingRoute(rawLatestLink, fallbackLink)
       const resolved = ensureExistingRoute(
@@ -68,8 +84,16 @@ function buildCategoryNavItems(navConfig: CategoryNavItem[]) {
         precomputed,
         fallbackLink
       )
-        category: title,
-        dir: rawDir,
+      const link = ensureExistingRoute(rawLink, fallbackLink)
+
+      return {
+        text: rawText || rawCategory || '',
+        category: title || rawCategory || '',
+        dir: rawDir || '',
+        link,
+        fallback: fallbackLink,
+        fallbackLink,
+        menuOrder: Number(rawMenuOrder ?? 0),
         latestLink: resolved,
         latestUpdatedAt: rawLatestUpdatedAt,
         latestTitle: rawLatestTitle,

--- a/scripts/lib/category-types.d.ts
+++ b/scripts/lib/category-types.d.ts
@@ -4,6 +4,7 @@ export interface CategoryNavItem {
   dir: string
   link: string
   fallback: string
+  fallbackLink?: string
   menuOrder: number
   latestLink?: string
   latestUpdatedAt?: string


### PR DESCRIPTION
## Summary
- ensure the VitePress category nav builder derives a single fallback URL for both the legacy and new fields
- expose the optional `fallbackLink` property on `CategoryNavItem` so downstream code can access it

## Testing
- CI=1 npm run docs:build

------
https://chatgpt.com/codex/tasks/task_e_68d9fda21e0883259d62ac273bc3d5be