### PR TITLE
fix: restore category fallback link handling

### DIFF
--- a/DEVELOPMENT_PROGRESS.md
+++ b/DEVELOPMENT_PROGRESS.md
@@ -24,6 +24,10 @@ This note summarizes the current state of the personal site project and highligh
 - **Docs**: expand contributor guide with the new column automation flow and auth requirements for running `blog-admin/server.mjs` locally.
 - **Nav observability**: surface `safeSyncCategoryNav` errors beyond the toast path—consider CLI fallbacks or build-time checks，使导航生成失败不会被忽视（目前导航已经从 JSON 加载，若生成失败将落回内嵌列表但仍需提醒开发者）。【F:blog-admin/server.mjs†L1221-L1298】【F:blog-admin/public/categories.js†L1-L205】
 
+## Postmortems
+
+- **分类导航第 5 次修复失败复盘**：在尝试恢复 `fallbackLink` 时错误地把菜单展示文案 (`text`) 作为类别主键，导致 `resolveLatestCategoryArticle` 去查找并不存在的分类，所有导航回退都会掉回 `/blog/`。修复方案是恢复“先读 `category`，再降级到 `text`”的顺序，确保真实分类名称参与文章扫描，回退链接才能落在最新文章或预置首页上。【F:docs/.vitepress/config.ts†L64-L85】
+
 ## Category Registry & Menu Integration
 
 - Replaced the legacy sections surface with a category registry (schema v2) stored in `docs/.vitepress/categories.map.json`. Each entry records `dir`, `title`, `menuLabel`, `publish`, `menuEnabled`, `menuOrder`, plus created/updated timestamps, and all admin mutations flow through `server.mjs` helpers that read/write this registry.【F:blog-admin/server.mjs†L180-L379】

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -61,15 +61,40 @@ function buildCategoryNavItems(navConfig: CategoryNavItem[]) {
       return String(a?.text || a?.category || '').localeCompare(String(b?.text || b?.category || ''))
     })
     .map((item) => {
+      const {
+        text: rawText,
+        category: rawCategory,
+        dir: rawDir,
+        link: rawLink,
+        fallback: rawFallback,
+        menuOrder: rawMenuOrder,
+        latestLink: rawLatestLink,
+        latestUpdatedAt: rawLatestUpdatedAt,
+        latestTitle: rawLatestTitle,
+        postCount: rawPostCount,
+        publishedCount: rawPublishedCount
+      } = item || ({} as CategoryNavItem)
+
+      const displayText = String(rawText || '').trim()
+      const canonicalCategory = String(rawCategory || '').trim() || displayText
+      const fallbackSource = String(rawFallback || rawLink || '')
       const fallbackLink = ensureExistingRoute(fallbackSource)
       const precomputed = ensureExistingRoute(rawLatestLink, fallbackLink)
       const resolved = ensureExistingRoute(
-        title ? resolveLatestCategoryArticle(title) : '',
+        canonicalCategory ? resolveLatestCategoryArticle(canonicalCategory) : '',
         precomputed,
         fallbackLink
       )
-        category: title,
-        dir: rawDir,
+      const link = ensureExistingRoute(rawLink, fallbackLink)
+
+      return {
+        text: displayText || canonicalCategory,
+        category: canonicalCategory,
+        dir: rawDir || '',
+        link,
+        fallback: fallbackLink,
+        fallbackLink,
+        menuOrder: Number(rawMenuOrder ?? 0),
         latestLink: resolved,
         latestUpdatedAt: rawLatestUpdatedAt,
         latestTitle: rawLatestTitle,

--- a/scripts/lib/category-types.d.ts
+++ b/scripts/lib/category-types.d.ts
@@ -4,6 +4,7 @@ export interface CategoryNavItem {
   dir: string
   link: string
   fallback: string
+  fallbackLink?: string
   menuOrder: number
   latestLink?: string
   latestUpdatedAt?: string


### PR DESCRIPTION
## Summary
- ensure the VitePress category nav builder derives a single fallback URL for both the legacy and new fields
- expose the optional `fallbackLink` property on `CategoryNavItem` so downstream code can access it
- restore category-first lookup when resolving latest articles to stop `/blog/` fallback loops and document the regression in the project log

## Testing
- CI=1 npm run docs:build

------
https://chatgpt.com/codex/tasks/task_e_68d9fda21e0883259d62ac273bc3d5be