### PR TITLE
fix(admin): avoid unpublished category nav routes

### DIFF
--- a/blog-admin/core/categories.mjs
+++ b/blog-admin/core/categories.mjs
@@ -468,8 +468,8 @@ function buildCategoryNavItems() {
       const stats = usage.get(title) || usage.get(category) || null;
       const latestPublished = stats?.latestPublished || null;
       const latestAny = stats?.latestAny || null;
+      const latestLink = latestPublished?.rel ? relToRoute(latestPublished.rel) : '';
       const best = latestPublished || latestAny;
-      const latestLink = best?.rel ? relToRoute(best.rel) : '';
       const latestUpdatedAt = best?.at || '';
       const latestTitle = best?.title || '';
       const fallback = latestLink || fallbackLink;

--- a/docs/.vitepress/categories.nav.json
+++ b/docs/.vitepress/categories.nav.json
@@ -1,5 +1,5 @@
 {
-  "updatedAt": "2025-09-28T12:47:29.066Z",
+  "updatedAt": "2025-09-29T05:52:49.430Z",
   "items": [
     {
       "text": "工程",
@@ -9,7 +9,7 @@
       "fallback": "/blog/engineering/blog-nav-offset-postmortem",
       "menuOrder": 2,
       "latestLink": "/blog/engineering/blog-nav-offset-postmortem",
-      "latestUpdatedAt": "2025-09-27T12:00:00.000Z",
+      "latestUpdatedAt": "2025-09-27T20:00:00.000Z",
       "latestTitle": "博客导航间距调试复盘",
       "postCount": 6,
       "publishedCount": 6
@@ -22,7 +22,7 @@
       "fallback": "/blog/guides/d2r-necromancer-guide",
       "menuOrder": 3,
       "latestLink": "/blog/guides/d2r-necromancer-guide",
-      "latestUpdatedAt": "2025-09-14T11:00:00.000Z",
+      "latestUpdatedAt": "2025-09-14T19:00:00.000Z",
       "latestTitle": "死灵法师 - 掌控生死（D2R职业攻略系列之七）",
       "postCount": 7,
       "publishedCount": 7
@@ -35,7 +35,7 @@
       "fallback": "/blog/mylife/life2",
       "menuOrder": 4,
       "latestLink": "/blog/mylife/life2",
-      "latestUpdatedAt": "2025-09-27T10:56:33.000Z",
+      "latestUpdatedAt": "2025-09-27T18:56:33.000Z",
       "latestTitle": "life2",
       "postCount": 2,
       "publishedCount": 2
@@ -48,7 +48,7 @@
       "fallback": "/blog/workplace/work",
       "menuOrder": 5,
       "latestLink": "/blog/workplace/work",
-      "latestUpdatedAt": "2025-09-28T03:57:37.000Z",
+      "latestUpdatedAt": "2025-09-28T11:57:37.000Z",
       "latestTitle": "work",
       "postCount": 2,
       "publishedCount": 1


### PR DESCRIPTION
## Summary
- update the category nav builder to only surface published posts when choosing the latest link
- resync docs/.vitepress/categories.nav.json so unpublished drafts no longer appear in the generated navigation

## Testing
- CI=1 npm run docs:build

------
https://chatgpt.com/codex/tasks/task_e_68da1e6f7bd88325a0207e4ecb37a634