### PR TITLE
fix: skip unpublished routes when resolving blog fallback

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -505,7 +505,13 @@ function ensureExistingRoute(candidate: string, ...fallbacks: string[]): string 
     const normalized = normalizeLink(String(option || ''))
     if (!normalized) continue
     const filePath = resolveFileForRoute(normalized)
-    if (filePath) return normalized
+    if (!filePath) continue
+    const block = extractFrontmatterBlockFile(filePath)
+    if (block) {
+      if (parseFrontmatterBoolean(block, 'publish') === false) continue
+      if (parseFrontmatterBoolean(block, 'draft') === true) continue
+    }
+    return normalized
   }
   return '/blog/'
 }


### PR DESCRIPTION
## Summary
- update `ensureExistingRoute` to ignore unpublished or draft blog article candidates while still accepting routes without frontmatter
- keep the `/blog/` fallback when no eligible article routes remain

## Testing
- npm run docs:dev *(fails: esbuild reports "Expected ';' but found ':'" in docs/.vitepress/config.ts around the admin navigation mapping block)*

------
https://chatgpt.com/codex/tasks/task_e_68da27d9492c83258d4c1437a22409f8