### PR TITLE
style(docs): realign catalog divider with article body

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -226,7 +226,8 @@ html.dark {
     border-radius: 0;
     position: relative;
     padding-right: 16px;
-    margin-right: 16px;
+    margin-left: 48px;
+    margin-right: -32px;
   }
 
   .blog-theme-layout:has(.VPContent:not(.is-home)) .VPSidebar .sidebar::after {
@@ -234,7 +235,7 @@ html.dark {
     position: absolute;
     top: 0;
     bottom: 0;
-    right: -16px;
+    right: 0;
     width: 1px;
     background: var(--vp-c-divider);
     pointer-events: none;


### PR DESCRIPTION
## Summary
- offset the article catalog sidebar container so its divider aligns to the right edge without touching the main article or "本页导航" columns
- anchor the catalog divider pseudo-element to the sidebar edge so the article body now sits centered between the two vertical rails (`docs/.vitepress/theme/custom.css`)

## Testing
- CI=1 npm run docs:build

------
https://chatgpt.com/codex/tasks/task_e_68da70169d908325a7f289f2b4cf077f