### PR TITLE
fix: prevent blog layout overflow on tablets

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -148,6 +148,24 @@ html.dark {
   }
 }
 
+@media (max-width: 1023.98px) {
+  .blog-theme-layout .content-wrapper {
+    flex-wrap: wrap;
+    justify-content: flex-start;
+    gap: 24px;
+  }
+
+  .blog-theme-layout .content-wrapper .blog-list-wrapper,
+  .blog-theme-layout .content-wrapper .blog-info-wrapper {
+    width: 100%;
+  }
+
+  .blog-theme-layout .content-wrapper .blog-info-wrapper {
+    margin-left: 0;
+    margin-top: 24px;
+  }
+}
+
 /* 文档页侧栏与正文卡片一致 */
 .blog-theme-layout:has(.VPContent:not(.is-home)) .VPSidebar {
   display: flex;


### PR DESCRIPTION
## Summary
- wrap the blog home content/aside columns on medium-width viewports to keep the layout within the viewport
- reset the sidebar spacing so the avatar card sits full-width on tablets

## Testing
- `CI=1 npm run docs:build`


------
https://chatgpt.com/codex/tasks/task_e_68dab0be8564832593cce351deef021f