### PR TITLE
fix(theme): sync article texture with content

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -319,12 +319,12 @@ html.dark {
 
 .blog-theme-layout .VPContent:not(.is-home)::before {
   content: '';
-  position: fixed;
+  position: absolute;
   inset: 0;
+  height: 100%;
   z-index: -1;
   background-image: var(--blog-bg-texture, none);
   background-repeat: repeat;
-  min-height: 100%;
   pointer-events: none;
 }
 


### PR DESCRIPTION
## Summary
- switch the blog article background texture pseudo-element to absolute positioning so it matches the VPContent height
- retain its stacking and pointer event behavior while letting the article container drive the texture height
- smoke-tested the blog article layout in Chromium desktop and WebKit iPad (portrait & landscape)

## Testing
- npm run docs:build

------
https://chatgpt.com/codex/tasks/task_e_68db381f08d88325af471478984e515d