### PR TITLE
fix(theme): match article texture opacity

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -17,6 +17,21 @@ html.dark {
   --xl-shadow: 0 12px 30px rgba(0, 0, 0, 0.35);
 }
 
+body {
+  position: relative;
+  background-color: var(--vp-c-bg);
+}
+
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  background-image: var(--blog-bg-texture, none);
+  background-repeat: repeat;
+  pointer-events: none;
+}
+
 /* 首页 Hero */
 .xl-hero {
   text-align: center;
@@ -315,17 +330,6 @@ html.dark {
       rgba(var(--bg-gradient-home), 1) 0%,
       rgba(var(--bg-gradient-home), 0) 700%
     );
-}
-
-.blog-theme-layout .VPContent:not(.is-home)::before {
-  content: '';
-  position: fixed;
-  inset: 0;
-  z-index: -1;
-  background-image: var(--blog-bg-texture, none);
-  background-repeat: repeat;
-  min-height: 100%;
-  pointer-events: none;
 }
 
 .blog-theme-layout .VPContent:not(.is-home) .VPDoc,


### PR DESCRIPTION
## Summary
- remove the extra tint and opacity from the global background texture so it matches the blog index in both color schemes
- rely on the existing gradient overlays to soften the pattern while keeping the content stack unchanged

## Screenshots
- [Article detail (light)](browser:/invocations/qzaizgzy/artifacts/artifacts/article-light.png)
- [Article detail (dark)](browser:/invocations/pwpydaxr/artifacts/artifacts/article-dark.png)

## Testing
- CI=1 npm run docs:build

------
https://chatgpt.com/codex/tasks/task_e_68db381f08d88325af471478984e515d