### PR TITLE
revert(theme): restore article texture baseline

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -148,24 +148,6 @@ html.dark {
   }
 }
 
-@media (max-width: 1023.98px) {
-  .blog-theme-layout .content-wrapper {
-    flex-wrap: wrap;
-    justify-content: flex-start;
-    gap: 24px;
-  }
-
-  .blog-theme-layout .content-wrapper .blog-list-wrapper,
-  .blog-theme-layout .content-wrapper .blog-info-wrapper {
-    width: 100%;
-  }
-
-  .blog-theme-layout .content-wrapper .blog-info-wrapper {
-    margin-left: 0;
-    margin-top: 24px;
-  }
-}
-
 /* 文档页侧栏与正文卡片一致 */
 .blog-theme-layout:has(.VPContent:not(.is-home)) .VPSidebar {
   display: flex;


### PR DESCRIPTION
## Summary
- remove the global body texture layer and return the article background pseudo-element to `.VPContent:not(.is-home)` so it matches the pre-regression styling
- drop the tablet flexbox overrides added in the reverted PR so the layout returns to its earlier baseline

## Testing
- CI=1 npm run docs:build

------
https://chatgpt.com/codex/tasks/task_e_68db381f08d88325af471478984e515d