### PR TITLE
fix: restore blog article texture overlay coverage

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -27,6 +27,7 @@ body::before {
   position: fixed;
   inset: 0;
   z-index: -1;
+}
 /* 首页 Hero */
 .xl-hero {
   text-align: center;
@@ -307,6 +308,17 @@ body::before {
       rgba(var(--bg-gradient-home), 1) 0%,
       rgba(var(--bg-gradient-home), 0) 700%
     );
+}
+
+.blog-theme-layout .VPContent:not(.is-home)::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  height: 100%;
+  z-index: -1;
+  background-image: var(--blog-bg-texture);
+  background-repeat: repeat;
+  pointer-events: none;
 }
 
 .blog-theme-layout .VPContent:not(.is-home) .VPDoc,


### PR DESCRIPTION
## Summary
- close the global `body::before` backdrop rule to restore the theme stylesheet
- ensure `docs/.vitepress/theme/custom.css` keeps the blog article texture pseudo-element positioned and spanning the full content with the texture repeat

## Testing
- CI=1 npm run docs:build *(fails to download pagefind binary on linux-x64; build completes without search index)*

## Screenshots
![Blog article texture – desktop](browser:/invocations/snrwdhwf/artifacts/artifacts/blog-article-desktop.png)
![Blog article texture – iPad portrait](browser:/invocations/oymzmidl/artifacts/artifacts/blog-article-ipad.png)

------
https://chatgpt.com/codex/tasks/task_e_68db913c6dec8325b0bb947d937772d8