### PR TITLE
fix(theme): remove article sidebar divider

### DIFF
--- a/docs/.vitepress/theme/BlogRecommendArticle.vue
+++ b/docs/.vitepress/theme/BlogRecommendArticle.vue
@@ -27,7 +27,7 @@ function toDisplayDate(value: any): string {
   return raw.replace(/-/g, '/').slice(0, 16)
 }
 
-function shortenTitle(title: string, limit = 10): string {
+function shortenTitle(title: string, limit = 9): string {
   const text = title.trim()
   if (text.length <= limit) return text
   if (limit <= 1) return text.slice(0, limit)

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,3 +1,7 @@
+html {
+  scrollbar-gutter: stable both-edges;
+}
+
 :root {
   /* 品牌与辅助色 */
   --vp-c-brand-1: #A1745D; /* mocha mousse */
@@ -219,34 +223,18 @@ html.dark {
 
 @media (min-width: 960px) {
   .blog-theme-layout:has(.VPContent:not(.is-home)) .VPSidebar .sidebar {
-    --xl-sidebar-fixed-width: calc(var(--vp-sidebar-width) - 64px);
-    --xl-sidebar-overflow-buffer: calc(
-      (var(--vp-sidebar-width) - var(--xl-sidebar-fixed-width)) / 2
-    );
+    --xl-sidebar-fixed-width: var(--vp-sidebar-width);
     flex: 0 0 var(--xl-sidebar-fixed-width);
     width: var(--xl-sidebar-fixed-width);
     min-width: var(--xl-sidebar-fixed-width);
-    background: transparent;
+    box-sizing: border-box;
+    background: var(--vp-c-bg);
     border: none;
     box-shadow: none;
-    padding: 0;
+    padding: 0 48px;
     border-radius: 0;
     position: relative;
-    padding-right: 16px;
-    margin-left: 48px;
-    margin-right: calc(var(--xl-sidebar-overflow-buffer) * -1);
-  }
-
-  .blog-theme-layout:has(.VPContent:not(.is-home)) .VPSidebar .sidebar::after {
-    content: '';
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    right: var(--xl-sidebar-overflow-buffer);
-    width: 1px;
-    background: var(--vp-c-divider);
-    pointer-events: none;
-    z-index: 1;
+    margin: 0;
   }
 
   .blog-theme-layout .VPSidebar .sidebar .card-header {


### PR DESCRIPTION
## Summary
- remove the article sidebar divider variables and border so the "同类文章目录" section no longer references an invisible rule
- rebalance the sidebar padding while keeping the layout constrained to `var(--vp-sidebar-width)`

## Testing
- npm run docs:dev -- --host 0.0.0.0 --port 5173

------
https://chatgpt.com/codex/tasks/task_e_68e1530c0108832593ce413a86fa23aa