### PR TITLE
chore: target modern CSS in docs build

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -269,6 +269,9 @@ export default defineConfig({
       blogUnlinkRestartPlugin(),
       adminNavWatcherPlugin(),
     ],
+    build: {
+      cssTarget: 'chrome105'
+    },
     resolve: {
       alias: {
         '@sugarat/theme/src/styles': path.resolve(process.cwd(), 'node_modules/@sugarat/theme/src/styles'),


### PR DESCRIPTION
## Summary
- set `cssTarget: 'chrome105'` in the VitePress configuration so `:has()` selectors survive minification

## Testing
- CI=1 npm run docs:build

------
https://chatgpt.com/codex/tasks/task_e_68e2865b66488325974a2be050a72569