### PR TITLE
style: restore sidebar divider opacity

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -269,6 +269,9 @@ export default defineConfig({
       blogUnlinkRestartPlugin(),
       adminNavWatcherPlugin(),
     ],
+    build: {
+      cssTarget: 'chrome105'
+    },
     resolve: {
       alias: {
         '@sugarat/theme/src/styles': path.resolve(process.cwd(), 'node_modules/@sugarat/theme/src/styles'),

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -227,6 +227,18 @@ html.dark {
     width: var(--xl-sidebar-fixed-width);
     min-width: var(--xl-sidebar-fixed-width);
     box-sizing: border-box;
+    position: relative;
+  }
+
+  .blog-theme-layout:has(.VPContent:not(.is-home)) .VPSidebar .sidebar::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: 1px;
+    background: var(--vp-c-brand-1);
+    pointer-events: none;
   }
 
   .blog-theme-layout .VPSidebar .sidebar .card-header {


### PR DESCRIPTION
## Summary
- restore the article sidebar divider pseudo-element to use the primary brand color at full opacity

## Testing
- CI=1 npm run docs:build

------
https://chatgpt.com/codex/tasks/task_e_68e2865b66488325974a2be050a72569