### PR TITLE
revert: drop sidebar divider pseudo-element

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -269,9 +269,6 @@ export default defineConfig({
       blogUnlinkRestartPlugin(),
       adminNavWatcherPlugin(),
     ],
-    build: {
-      cssTarget: 'chrome105'
-    },
     resolve: {
       alias: {
         '@sugarat/theme/src/styles': path.resolve(process.cwd(), 'node_modules/@sugarat/theme/src/styles'),

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -227,17 +227,6 @@ html.dark {
     width: var(--xl-sidebar-fixed-width);
     min-width: var(--xl-sidebar-fixed-width);
     box-sizing: border-box;
-    position: relative;
-  }
-
-  .blog-theme-layout:has(.VPContent:not(.is-home)) .VPSidebar .sidebar::after {
-    content: '';
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    width: 1px;
-    pointer-events: none;
   }
 
   .blog-theme-layout .VPSidebar .sidebar .card-header {


### PR DESCRIPTION
## Summary
- remove the desktop sidebar ::after divider styling from the theme override
- drop the Vite build cssTarget override so default targets apply again

## Testing
- CI=1 npm run docs:build -- --logLevel warn

------
https://chatgpt.com/codex/tasks/task_e_68e32e5fcb288325ac8e9a53849b4c2c