### PR TITLE
docs: relocate pagegen planning docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,3 +21,7 @@ Never commit secrets or generated `docs/.vitepress/dist/` artifacts; rely on `.g
 ## Performance Optimization
 - **Code-level:** 优先加载首页 hero 背景图（fetchpriority=high 或使用 <link rel=preload as=image>），压缩封面为 WebP/AVIF；延迟加载文章封面与 Pagefind JS；对滚动容器使用 contain/will-change 减少全局回流。
 - **Engineering-level:** 引入前置 CDN 或迁移至延迟更低的平台以降低 GitHub Pages TTFB；在可自定义响应头的平台上为带哈希的静态资产设置长期 Cache-Control。
+
+## Progress
+
+- Pagegen orchestrator refactor：██████████ 100%（Stage 1 契约巩固与守门补全已完成，详见 `docs/zh/plans/pagegen-refactor-roadmap.md`）。

--- a/docs/zh/plans/module-inventory.md
+++ b/docs/zh/plans/module-inventory.md
@@ -1,0 +1,31 @@
+---
+title: Pagegen 模块清单
+publish: false
+---
+
+# Module Inventory
+
+> Progress: ████████░░ 80% — Pagegen 栈的核心模块已经完成契约梳理，仅剩回滚策略与模型桥接待收口。
+
+| 模块 | 描述 | 状态 | 负责人 | 下一步 |
+| --- | --- | --- | --- | --- |
+| `orchestrator/core.ts` | 阶段编排与契约绑定，现已补齐阶段输入/输出定义。 | ✅ 稳定 | Pagegen 团队 | 关注阶段扩展的回归测试。 |
+| `orchestrator/guards.ts` | 预检守门逻辑，新增 nav/i18n 缺失即时异常。 | ✅ 稳定 | Pagegen 团队 | 观察 CI 报警表现。 |
+| `scripts/check-links.mjs` | 导航裁剪与跨语言映射兜底校验。 | ✅ 稳定 | Tooling | 与 nightly stats 对比联动。 |
+| `scripts/stats-lint.mjs` | 指标对比与异常提示。 | 🚧 进行中 | Tooling | 接入 nightly / PR pipeline。 |
+| `data/pagegen-metrics.json` | Metrics 导出与缓存命中摘要。 | ✅ 稳定 | Telemetry | 扩展 snapshot diff。 |
+| `scripts/embed-build.mjs` | AI 管线钩子，梳理事件接口。 | 🚧 进行中 | AI 小组 | 结合 Stage 3 模型落地。 |
+| `scripts/summary.mjs` | 生成摘要的 AI 钩子。 | 🚧 进行中 | AI 小组 | 明确模型托管策略。 |
+| `scripts/qa-build.mjs` | QA 自动问答钩子。 | 🚧 进行中 | AI 小组 | 整合回滚策略。 |
+
+## 指标观察
+
+- collect 缓存命中率、writer hash 命中率已在 CLI telemetry 中暴露。
+- stdout 摘要补充缓存命中、写入跳过等指标，夜间任务将比对 `data/pagegen-metrics.json`。
+- Nightly / PR 对比任务由 `scripts/stats-lint.mjs` 承担，异常差异将触发提示或标签。
+
+## 风险与后续
+
+- AI 模型接入仍在规划，需要确认 Transformers.js 与 onnxruntime 的混合部署方案。
+- 夜间任务需要与 CI 配合，确保 nav/i18n 预检异常能在生成前阻断。
+- 关注多语言目标路径扩展对 orchestrator 契约的影响，必要时补充更多阶段粒度的度量。

--- a/docs/zh/plans/pagegen-refactor-roadmap.md
+++ b/docs/zh/plans/pagegen-refactor-roadmap.md
@@ -1,0 +1,45 @@
+---
+title: Pagegen 重构路线图
+publish: false
+---
+
+# Pagegen Refactor Roadmap
+
+> Progress: ██████████ 100% — Stage 1 (契约巩固与守门补全) 已交付，后续阶段按既定节奏推进。
+
+## Stage 1 · 契约巩固与守门补全
+
+- [x] 梳理 orchestrator 各阶段输入/输出契约，确保依赖顺序与产物定义统一。
+- [x] 扩充 `npm run test:pagegen`，覆盖端到端流程、metrics 导出与失败回滚路径。
+- [x] 收敛错误日志格式，统一输出阶段/locale/target 以便 CI 与可观测性定位。
+- [x] 显式化导航与 i18n 故障：在 registry / manifest 缺失时即时抛错并补强单测。
+- [x] 在 `normalizeAggregates` 等关键分支直接抛出配置缺失异常，带定位信息。
+- [x] 新增预检失败用例，覆盖 nav/i18n 配置缺失或拼写错误的阻断路径。
+- [x] 借助 `scripts/check-links.mjs` 与主题测试验证导航裁剪与跨语言映射兜底行为。
+- [x] 扩展 telemetry 采集：暴露 collect 缓存命中率、writer hash 命中等指标。
+- [x] 扩展 `data/pagegen-metrics.json` 与 stdout 摘要，输出缓存命中、写入跳过等关键指标。
+- [x] 设计 `scripts/stats-lint.mjs` 对比任务，夜间/PR 触发异常差异提示或标签。
+- [x] 评估 README / 运维文档中的统计监控与告警流程指引。
+- [x] 明确 Transformers.js / onnxruntime 接入计划，梳理脚本接口、模型托管与回滚策略。
+- [x] 盘点 `scripts/embed-build.mjs`、`scripts/summary.mjs`、`scripts/qa-build.mjs` 钩子，确定需要暴露的事件与配置。
+- [x] 评估浏览器端与 Node 端模型加载方案，列出性能、依赖、安全考量与实验环境。
+- [x] 在 Expansion/README 中记录落地路线与回滚流程。
+
+## Stage 2 · Pipeline 硬化（进行中）
+
+> Progress: ████░░░░░ 40% — 继续针对缓存失效、增量写入与回滚策略展开实验。
+
+- [x] 拆分 orchestrator Stage 定位，准备引入增量生成模式。
+- [ ] 引入可配置的 Writer sandbox，隔离副作用输出。
+- [ ] 设计逐阶段缓存命中率告警与自动退避策略。
+- [ ] 扩大 PR 验证矩阵，涵盖多语言与多目标路径场景。
+
+## Stage 3 · AI Pipeline 一体化（规划中）
+
+> Progress: ░░░░░░░░░░ 0% — 等待 Stage 2 确认后再排期。
+
+- [ ] 接入 AI Draft/Review 管线，串联 Summary / QA / Embed 产物。
+- [ ] 建立模型更新回滚 SOP 与指标看板。
+- [ ] 完成数据敏感性审核与合规评估。
+
+请在每个阶段迭代后同步更新此路线图的勾选项与进度条，保持多代理协作透明。


### PR DESCRIPTION
## Summary
- move the Pagegen refactor roadmap and module inventory docs into `docs/zh/plans/` with VitePress frontmatter
- update the root agent progress note to reference the relocated roadmap

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f4a814b26883258c20122a18ad8786